### PR TITLE
contentfulの親コントローラー名を修正

### DIFF
--- a/app/controllers/contentfuls_controller.rb
+++ b/app/controllers/contentfuls_controller.rb
@@ -1,4 +1,4 @@
-class ContentfulsController < ActionController::API
+class ContentfulsController < ApplicationController
   def index
     foo = Contentful::Foo.first
 


### PR DESCRIPTION
APIを継承したcontentfulController
contentfulControllerを継承した各テーブル名コントローラー

URL例
~/contentful/foos/5
~/contentful/foos/1
~/contentful/foos

あとで調整。